### PR TITLE
Add an optional :offload send mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ were finally able to keep up with their message queues.
 
 ![Packets Out Reduction](priv/packets.png)
 
+There is an optional `:offload` send mode which offloads the `send/2` calls to one of the local `Manifold.Partitioner` processes
+to send the messages to the remote Manifold nodes. These `Manifold.Partitioner` processes would otherwise be unused on the send
+side.
+
 ## Usage
 
 Add it to `mix.exs`
@@ -40,6 +44,13 @@ Then just use it like the normal `send/2` except it can also take a list of PIDs
 ```elixir
 Manifold.send(self(), :hello)
 Manifold.send([self(), self()], :hello)
+```
+
+To use the optional `:offload` send mode:
+
+```elixir
+Manifold.send(self(), :hello, :offload)
+Manifold.send([self(), self()], :hello, :offload)
 ```
 
 ### Configuration

--- a/lib/manifold/partitioner.ex
+++ b/lib/manifold/partitioner.ex
@@ -25,6 +25,11 @@ defmodule Manifold.Partitioner do
     @gen_module.cast(pid, {:send, pids, message})
   end
 
+  @spec offload_send(pid, [pid], term) :: :ok
+  def offload_send(pid, pids, message) do
+    @gen_module.cast(pid, {:offload_send, pid, pids, message})
+  end
+
   ## Server Callbacks
 
   def init(partitions) do
@@ -72,6 +77,15 @@ defmodule Manifold.Partitioner do
     partitions = tuple_size(state)
     pids_by_partition = Utils.partition_pids(pids, partitions)
     do_send(message, pids_by_partition, state, 0, partitions)
+    {:noreply, state}
+  end
+
+  def handle_cast({:offload_send, partitioner_name, pids, message}, state) do
+    grouped_by = Utils.group_by(pids, fn
+      nil -> nil
+      pid -> node(pid)
+    end)
+    for {node, pids} <- grouped_by, node != nil, do: Manifold.Partitioner.send({partitioner_name, node}, pids, message)
     {:noreply, state}
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,11 @@ defmodule Manifold.Mixfile do
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       deps: deps(),
-      package: package()
+      package: package(),
+      # https://github.com/whitfin/local-cluster#setup
+      aliases: [
+        test: "test --no-start"
+      ]
     ]
   end
 
@@ -22,7 +26,8 @@ defmodule Manifold.Mixfile do
 
   defp deps do
     [
-      {:benchfella, "~> 0.3.0", only: :test}
+      {:benchfella, "~> 0.3.0", only: :test},
+      {:local_cluster, "~> 1.2", only: [:test]}
     ]
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,5 @@
+# https://github.com/whitfin/local-cluster#setup
+:ok = LocalCluster.start()
+Application.ensure_all_started(:manifold)
+
 ExUnit.start()


### PR DESCRIPTION
This optional mode offloads the send/2 calls to the remote Manifold nodes
to one of the local `Manifold.Partitioner` processes.

Those processes on the send side are otherwise unused. This gives the
caller an option to further free up the sender process.

Add a new test for the :offload send mode.