### PR TITLE
Relax send_mode validation...

### DIFF
--- a/lib/manifold.ex
+++ b/lib/manifold.ex
@@ -45,7 +45,7 @@ defmodule Manifold do
       :offload ->
         Sender.send(current_sender(), current_partitioner(), pids, message)
 
-      nil ->
+      _ ->
         partitioner_name = current_partitioner()
 
         grouped_by =
@@ -69,7 +69,7 @@ defmodule Manifold do
         # it to the sender process, even for a single receiving pid.
         Sender.send(current_sender(), current_partitioner(), [pid], message)
 
-      nil ->
+      _ ->
         Partitioner.send({current_partitioner(), node(pid)}, [pid], message)
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Manifold.Mixfile do
   def project do
     [
       app: :manifold,
-      version: "1.5.0",
+      version: "1.5.1",
       elixir: "~> 1.5",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,

--- a/test/manifold_test.exs
+++ b/test/manifold_test.exs
@@ -59,6 +59,18 @@ defmodule ManifoldTest do
     assert_receive ^message
   end
 
+  test "send with unknown send_mode option wont blow up" do
+    me = self()
+    message = :hello
+    pid = spawn_link fn ->
+      receive do
+        message -> send(me, message)
+      end
+    end
+    Manifold.send(pid, message, send_mode: :bad_option)
+    assert_receive ^message
+  end
+
   test "send with pinned process" do
     me = self()
     message = :hello


### PR DESCRIPTION
... so an unknown option falls back to the default send behavior